### PR TITLE
feat(hm): home-manager flake scaffold + gitconfig migration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,25 +1,5 @@
 {
   "nodes": {
-    "home-manager": {
-      "inputs": {
-        "nixpkgs": [
-          "nixpkgs"
-        ]
-      },
-      "locked": {
-        "lastModified": 1774738535,
-        "narHash": "sha256-2jfBEZUC67IlnxO5KItFCAd7Oc+1TvyV/jQlR+2ykGQ=",
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "rev": "769e07ef8f4cf7b1ec3b96ef015abec9bc6b1e2a",
-        "type": "github"
-      },
-      "original": {
-        "owner": "nix-community",
-        "repo": "home-manager",
-        "type": "github"
-      }
-    },
     "nixpkgs": {
       "locked": {
         "lastModified": 1774386573,
@@ -38,7 +18,6 @@
     },
     "root": {
       "inputs": {
-        "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -3,11 +3,6 @@
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-
-    home-manager = {
-      url = "github:nix-community/home-manager";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
   };
 
   outputs = { self, ... }: {

--- a/modules/nick.nix
+++ b/modules/nick.nix
@@ -1,4 +1,4 @@
-{ pkgs, lib, ... }: {
+{ ... }: {
 
   programs.git = {
     enable = true;


### PR DESCRIPTION
## why

First step toward making dotfiles the source of truth for "nick on any unix" (iamnande/dotfiles#4). Adds a home-manager flake exposing `homeManagerModules.nick` so the homelab repo can consume it as a flake input instead of cloning and stowing on first boot.

## how

- `flake.nix` — exposes `homeManagerModules.nick = import ./modules/nick.nix`. nixpkgs pinned to unstable; no home-manager input needed (consumer provides HM context)
- `modules/nick.nix` — gitconfig fully migrated to `programs.git`:
  - identity, SSH GPG signing, editor, fetch/push/diff/advice settings via `programs.git.settings`
  - aliases (`up`, `lg`, `stat`, `merged`) preserved exactly
  - global gitignore (`.DS_Store`, `.idea/`) via `programs.git.ignores` — HM manages `core.excludesfile` automatically
- `src/gitconfig` stow files intentionally left in place — removed when all components have migrated and stow is dropped

**key decisions:**
- `homeManagerModules` (not `nixosModules`) — keeps the module portable for future darwin use
- `programs.git.settings` API used throughout — avoids deprecated `extraConfig`/`userName`/`aliases` options
- `home.stateVersion` stays in homelab — environment-specific, not this module's concern

## validation

```bash
# verify flake evaluates cleanly
nix flake check

# verify alias strings render correctly (no Nix interpolation leaking through)
nix eval --raw --impure --expr \
  '(import ./modules/nick.nix {}).programs.git.settings.alias.up'
# expect: ${default:-main} appears literally in output

# after homelab PR merges and devbox-nick rebuilds:
git config --list --show-origin
# expect: entries show /nix/store/... not ~/dotfiles/.gitconfig

git commit --allow-empty -m "test signing" && git log --show-signature -1
# expect: gpg signature present (requires 1Password agent running — see dotfiles#6)
```