### PR TITLE
feat(helix): migrate helix config to home-manager

### DIFF
--- a/mk/setup.mk
+++ b/mk/setup.mk
@@ -25,11 +25,6 @@ claude: ## setup: claude global context (~/.claude/CLAUDE.md)
 	$(install)
 
 
-.PHONY: helix
-helix: COMPONENT=helix
-helix: ## setup: helix
-	@echo $(log) "installing helix configs"
-	$(install)
 
 .PHONY: hypr
 hypr: COMPONENT=hypr

--- a/modules/nick.nix
+++ b/modules/nick.nix
@@ -108,4 +108,15 @@
   # tide prompt config — sourced on every shell start
   xdg.configFile."fish/conf.d/tide.fish".source = ./fish/tide.fish;
 
+  programs.helix = {
+    enable = true;
+    settings = {
+      theme = "everforest_dark";
+      editor.file-picker = {
+        hidden = false;
+        git-ignore = true;
+      };
+    };
+  };
+
 }

--- a/src/helix/.config/helix/config.toml
+++ b/src/helix/.config/helix/config.toml
@@ -1,5 +1,0 @@
-theme = "everforest_dark"
-
-[editor.file-picker]
-hidden = false
-git-ignore = true


### PR DESCRIPTION
## why

migrates helix stow component into `homeManagerModules.nick`. dotfiles#4.

## how

- `programs.helix.enable` + `settings` (theme, file-picker)
- `src/helix/` removed, `make helix` dropped

## validation

```fish
cat ~/.config/helix/config.toml  # sourced from nix store
hx --version                     # launches clean
```